### PR TITLE
PT navigation link removed for other than PT employee

### DIFF
--- a/data/od/ACCESSCONTROL-ROLEACTIONS/roleactions.json
+++ b/data/od/ACCESSCONTROL-ROLEACTIONS/roleactions.json
@@ -8367,20 +8367,8 @@
       "tenantId": "od"
     },
     {
-      "rolecode": "EMPLOYEE",
-      "actionid": 1547,
-      "actioncode": "",
-      "tenantId": "od"
-    },
-    {
       "rolecode": "SUPERUSER",
       "actionid": 1547,
-      "actioncode": "",
-      "tenantId": "od"
-    },
-    {
-      "rolecode": "EMPLOYEE",
-      "actionid": 1548,
       "actioncode": "",
       "tenantId": "od"
     },
@@ -8933,12 +8921,6 @@
     {
       "rolecode": "PGR-ADMIN",
       "actionid": 1580,
-      "actioncode": "",
-      "tenantId": "od"
-    },
-    {
-      "rolecode": "EMPLOYEE",
-      "actionid": 1584,
       "actioncode": "",
       "tenantId": "od"
     },
@@ -13829,12 +13811,6 @@
     {
       "rolecode": "CSR",
       "actionid": 1925,
-      "actioncode": "",
-      "tenantId": "od"
-    },
-    {
-      "rolecode": "EMPLOYEE",
-      "actionid": 1926,
       "actioncode": "",
       "tenantId": "od"
     },
@@ -19074,6 +19050,30 @@
     {
       "rolecode": "WS_CLERK",
       "actionid": 1882,
+      "actioncode": "",
+      "tenantId": "od"
+    },
+    {
+      "rolecode": "PT_CEMP",
+      "actionid": 1926,
+      "actioncode": "",
+      "tenantId": "od"
+    },
+    {
+      "rolecode": "PT_DOC_VERIFIER",
+      "actionid": 1926,
+      "actioncode": "",
+      "tenantId": "od"
+    },
+    {
+      "rolecode": "PT_FIELD_INSPECTOR",
+      "actionid": 1926,
+      "actioncode": "",
+      "tenantId": "od"
+    },
+    {
+      "rolecode": "PT_APPROVER",
+      "actionid": 1926,
       "actioncode": "",
       "tenantId": "od"
     }


### PR DESCRIPTION
PT navigation link removed for other than PT employee.
Only search link retain. There are few link related to report. For now revoke the access.